### PR TITLE
fix: 11 add analytics

### DIFF
--- a/source/js/features/_2-load-plausible.js
+++ b/source/js/features/_2-load-plausible.js
@@ -1,9 +1,9 @@
-(function() {
+(function () {
 	// When any page loads lat.js, send a custom event via LTC Plausible (utils.js).
 	// Uses common.ltc.bcit.ca/js/utils.js so adblockers don't block it.
-	window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments); };
+	window.plausible = window.plausible || function () { (window.plausible.q = window.plausible.q || []).push(arguments); };
 	if (!window.plausible.o) window.plausible.o = { captureOnLocalhost: true, autoCapturePageviews: true };
-	if (!window.ltcDomain) window.ltcDomain = { eventDomain: 'sugar-suite.latest.ltc.bcit.ca' };
+	if (!window.ltcDomain) window.ltcDomain = { eventDomain: 'sugar-suite.ltc.bcit.ca' };
 	function nonEmpty(value) {
 		if (value === null || value === undefined) return '';
 		return String(value).trim();
@@ -36,7 +36,7 @@
 			}
 		}
 	}
-	
+
 	var computedLatScriptUrl = '';
 	try {
 		computedLatScriptUrl = new URL('js/lat.js', document.baseURI || window.location.href).href;
@@ -45,7 +45,7 @@
 	}
 	latScriptUrl = nonEmpty(latScriptUrl) || nonEmpty(computedLatScriptUrl);
 	if (!pageUrl) return;
-	var pageAndScript = pageUrl + ' | ' + latScriptUrl;
+	var scriptLocation = JSON.stringify({ page: pageUrl, scriptUrl: latScriptUrl });
 
 	// Avoid sending duplicate events from repeated initializations.
 	var dedupeHost = window;
@@ -55,11 +55,11 @@
 		dedupeHost = window;
 	}
 	dedupeHost.__latPlausibleEvents = dedupeHost.__latPlausibleEvents || {};
-	if (dedupeHost.__latPlausibleEvents[pageAndScript]) return;
-	dedupeHost.__latPlausibleEvents[pageAndScript] = true;
+	if (dedupeHost.__latPlausibleEvents[scriptLocation]) return;
+	dedupeHost.__latPlausibleEvents[scriptLocation] = true;
 
-	plausible('lat.js loaded', { props: { page: pageUrl, scriptUrl: latScriptUrl, pageAndScript: pageAndScript } });
-	
+	plausible('lat.js location', {props: { scriptUrl: latScriptUrl, scriptLocation: scriptLocation }});
+
 	var s = document.createElement('script');
 	s.defer = true;
 	s.src = 'https://common.ltc.bcit.ca/js/utils.js';

--- a/source/js/features/_2-load-plausible.js
+++ b/source/js/features/_2-load-plausible.js
@@ -2,8 +2,8 @@
 	// When any page loads lat.js, send a custom event via LTC Plausible (utils.js).
 	// Uses common.ltc.bcit.ca/js/utils.js so adblockers don't block it.
 	window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments); };
-	if (!window.plausible.o) window.plausible.o = { captureOnLocalhost: false, autoCapturePageviews: true };
-	if (!window.ltcDomain) window.ltcDomain = { eventDomain: 'sugar-suite.ltc.bcit.ca' };
+	if (!window.plausible.o) window.plausible.o = { captureOnLocalhost: true, autoCapturePageviews: true };
+	if (!window.ltcDomain) window.ltcDomain = { eventDomain: 'sugar-suite.latest.ltc.bcit.ca' };
 	function nonEmpty(value) {
 		if (value === null || value === undefined) return '';
 		return String(value).trim();

--- a/source/js/features/_2-load-plausible.js
+++ b/source/js/features/_2-load-plausible.js
@@ -2,7 +2,7 @@
 	// When any page loads lat.js, send a custom event via LTC Plausible (utils.js).
 	// Uses common.ltc.bcit.ca/js/utils.js so adblockers don't block it.
 	window.plausible = window.plausible || function () { (window.plausible.q = window.plausible.q || []).push(arguments); };
-	if (!window.plausible.o) window.plausible.o = { captureOnLocalhost: true, autoCapturePageviews: true };
+	if (!window.plausible.o) window.plausible.o = { captureOnLocalhost: false, autoCapturePageviews: true };
 	if (!window.ltcDomain) window.ltcDomain = { eventDomain: 'sugar-suite.ltc.bcit.ca' };
 	function nonEmpty(value) {
 		if (value === null || value === undefined) return '';

--- a/source/js/features/_3-analytics-tracker.js
+++ b/source/js/features/_3-analytics-tracker.js
@@ -1,0 +1,100 @@
+(function () {
+    function getStorageHost() {
+        var host = window;
+        try {
+            if (window.top && window.top.sessionStorage) {
+                host = window.top;
+            }
+        } catch (e) {
+            host = window;
+        }
+        return host;
+    }
+
+    var storageHost = getStorageHost();
+    var storageKey = "sugarSuiteAnalyticsSent";
+    var sent = {};
+
+    function readSent() {
+        try {
+            var raw = storageHost.sessionStorage.getItem(storageKey);
+            if (raw) {
+                sent = JSON.parse(raw) || {};
+            }
+        } catch (e) {
+            sent = {};
+        }
+    }
+
+    function saveSent() {
+        try {
+            storageHost.sessionStorage.setItem(storageKey, JSON.stringify(sent));
+        } catch (e) {
+            // ignore storage errors
+        }
+    }
+
+    function buildContext(data) {
+        var context = {};
+
+        if (data && typeof data === "object") {
+            Object.keys(data).forEach(function (key) {
+                context[key] = data[key];
+            });
+        }
+
+        return context;
+    }
+
+    function canTrack() {
+        return typeof window.plausible === "function";
+    }
+
+    function dedupeId(eventName, propertyName, contextString, customDedupeKey) {
+        if (customDedupeKey) {
+            return eventName + "|" + propertyName + "|" + customDedupeKey;
+        }
+        return eventName + "|" + propertyName + "|" + contextString;
+    }
+
+    readSent();
+
+    window.SugarAnalytics = {
+        trackEvent: function (eventName, propertyName, data, options) {
+            if (!canTrack()) {
+                return false;
+            }
+
+            var config = options || {};
+            var shouldDedupe = config.dedupe !== false;
+            var context = buildContext(data);
+            var contextString = JSON.stringify(context);
+
+            if (shouldDedupe) {
+                var id = dedupeId(eventName, propertyName, contextString, config.dedupeKey);
+                if (sent[id]) {
+                    return false;
+                }
+                sent[id] = true;
+                saveSent();
+            }
+
+            var props = {};
+            props[propertyName] = contextString;
+            window.plausible(eventName, { props: props });
+            return true;
+        },
+
+        trackFeature: function (featureType, actionName, data, options) {
+            return this.trackEvent(featureType + " stats", actionName, data, options);
+        },
+
+        trackPageStats: function (propertyName, counts, options) {
+            return this.trackEvent("Page stats", propertyName, counts, options);
+        },
+
+        makeInstanceKey: function (prefix, instanceIndex) {
+            return prefix + "_" + String(instanceIndex);
+        }
+    };
+}());

--- a/source/js/features/_4-page-stats.js
+++ b/source/js/features/_4-page-stats.js
@@ -133,7 +133,7 @@
         var legacySelfTestCount = $(".self-test").length;
         if (legacySelfTestCount > 0) {
             window.SugarAnalytics.trackFeature("Legacy Class Used", "legacySelfTestClass", {
-                page: window.location.pathname,
+                page: window.location.href,
                 count: legacySelfTestCount
             });
         }
@@ -141,7 +141,7 @@
         var legacyImageClassCount = $("figure.image").length;
         if (legacyImageClassCount > 0) {
             window.SugarAnalytics.trackFeature("Legacy Class Used", "legacyImageClass", {
-                page: window.location.pathname,
+                page: window.location.href,
                 count: legacyImageClassCount
             });
         }
@@ -149,7 +149,7 @@
         var legacyRevealMinTextCount = $(".reveal[data-min-text]").length;
         if (legacyRevealMinTextCount > 0) {
             window.SugarAnalytics.trackFeature("Legacy Class Used", "legacyRevealMinTextPattern", {
-                page: window.location.pathname,
+                page: window.location.href,
                 count: legacyRevealMinTextCount
             });
         }

--- a/source/js/features/_4-page-stats.js
+++ b/source/js/features/_4-page-stats.js
@@ -1,0 +1,157 @@
+(function ($) {
+    var featureSelectors = {
+        sliders: ".slider",
+        knowledge_checks: ".knowledge-check",
+        accordions: ".accordion",
+        flashcards: ".flashcards",
+        tabs: ".tabs",
+        line_matchings: ".line-matching",
+        reveals: ".reveal",
+        active_reveals: ".active-reveal",
+        swappers: ".swapper",
+        checklists: ".checklist",
+        images: "figure.image, figure.img",
+        audio: "figure.audio",
+        videos: "figure.video",
+        math: "figure.math",
+        blockquotes: "blockquote:not(.pull-quote)",
+        pull_quotes: "blockquote.pull-quote, .pullquote",
+        references: ".reference, .ref",
+        side_by_sides: ".side-by-side",
+        tables: "figure.table"
+    };
+
+    var learningBlockTypes = [
+        "activity", "case", "discussion", "group-activity", "outcome",
+        "reading", "reflection", "review", "doing",
+        "example", "definition", "key-point", "link", "note", "warning", "knowing",
+        "assignment", "quiz"
+    ];
+
+    function getFileTypeFromUrl(url) {
+        if (!url) {
+            return "unknown";
+        }
+
+        var cleaned = url.split("#")[0].split("?")[0];
+        var lastSlash = cleaned.lastIndexOf("/");
+        var filename = lastSlash >= 0 ? cleaned.substring(lastSlash + 1) : cleaned;
+        var lastDot = filename.lastIndexOf(".");
+
+        if (lastDot <= 0 || lastDot === filename.length - 1) {
+            return "unknown";
+        }
+
+        return filename.substring(lastDot + 1).toLowerCase();
+    }
+
+    function getMediaSource($root, selectors) {
+        var source = "";
+        selectors.some(function (selector) {
+            var candidate = $root.find(selector).first().attr("src") || "";
+            if (candidate) {
+                source = candidate;
+                return true;
+            }
+            return false;
+        });
+        return source;
+    }
+
+    $(window).on("load", function () {
+        if (!window.SugarAnalytics) {
+            return;
+        }
+
+        var pageCounts = {};
+        Object.keys(featureSelectors).forEach(function (key) {
+            var count = $(featureSelectors[key]).length;
+            if (count > 0) {
+                pageCounts[key] = count;
+            }
+        });
+
+        if (Object.keys(pageCounts).length > 0) {
+            window.SugarAnalytics.trackPageStats("features", pageCounts);
+        }
+
+        var blockCounts = {};
+        learningBlockTypes.forEach(function (type) {
+            var count = $("." + type).length;
+            if (count > 0) {
+                blockCounts[type] = count;
+            }
+        });
+
+        if (Object.keys(blockCounts).length > 0) {
+            window.SugarAnalytics.trackFeature("Learning Block", "learningBlocks", blockCounts);
+        }
+
+        $("figure.interaction iframe").each(function (index) {
+            var src = $(this).attr("src") || "";
+            window.SugarAnalytics.trackFeature("Custom Interaction", "customInteractions", {
+                src: src
+            }, {
+                dedupeKey: "custom_interaction_" + index + "_" + src
+            });
+        });
+
+        $("figure.image img, figure.img img").each(function (index) {
+            var src = $(this).attr("src") || "";
+            window.SugarAnalytics.trackFeature("Image", "imageLoaded", {
+                file_type: getFileTypeFromUrl(src)
+            }, {
+                dedupeKey: "image_loaded_" + index + "_" + src
+            });
+        });
+
+        $("figure.video").each(function (index) {
+            var $figure = $(this);
+            var src = getMediaSource($figure, ["video", "video source", "iframe"]);
+            var fileType = src ? getFileTypeFromUrl(src) : "unknown";
+            if (src && $figure.find("iframe").length) {
+                fileType = "url";
+            }
+
+            window.SugarAnalytics.trackFeature("Responsive Video", "videoLoaded", {
+                file_type: fileType
+            }, {
+                dedupeKey: "video_loaded_" + index + "_" + src
+            });
+        });
+
+        $("figure.audio").each(function (index) {
+            var $figure = $(this);
+            var src = getMediaSource($figure, ["audio", "audio source"]);
+            window.SugarAnalytics.trackFeature("Responsive Video", "audioLoaded", {
+                file_type: getFileTypeFromUrl(src)
+            }, {
+                dedupeKey: "audio_loaded_" + index + "_" + src
+            });
+        });
+
+        var legacySelfTestCount = $(".self-test").length;
+        if (legacySelfTestCount > 0) {
+            window.SugarAnalytics.trackFeature("Legacy Class Used", "legacySelfTestClass", {
+                page: window.location.pathname,
+                count: legacySelfTestCount
+            });
+        }
+
+        var legacyImageClassCount = $("figure.image").length;
+        if (legacyImageClassCount > 0) {
+            window.SugarAnalytics.trackFeature("Legacy Class Used", "legacyImageClass", {
+                page: window.location.pathname,
+                count: legacyImageClassCount
+            });
+        }
+
+        var legacyRevealMinTextCount = $(".reveal[data-min-text]").length;
+        if (legacyRevealMinTextCount > 0) {
+            window.SugarAnalytics.trackFeature("Legacy Class Used", "legacyRevealMinTextPattern", {
+                page: window.location.pathname,
+                count: legacyRevealMinTextCount
+            });
+        }
+    });
+}(jQuery));

--- a/source/js/features/accordion.js
+++ b/source/js/features/accordion.js
@@ -1,6 +1,7 @@
 
 (function () {
 	// Accordion 
+	var accordionInstanceIndex = 0;
 
 	var keycodes = {
 		space: 32,
@@ -17,6 +18,7 @@
 	
 	// Transform Accordion
     $(".accordion").each(function (index) {
+        $(this).attr("data-accordion-instance", accordionInstanceIndex++);
         var toggleTag = $(this).children().first().prop("tagName");
 
         $(this).children(toggleTag).each(function () {
@@ -39,6 +41,9 @@
 	$(".accordion-button").on("click keyup", function(e, isToggle) {
 		if (isActivationEvent(e)) {
 			e.preventDefault();
+			var $accordion = $(this).closest(".accordion");
+			var accordionId = $accordion.attr("data-accordion-instance") || "0";
+			var totalPanels = $accordion.find(".accordion-button").length;
 			var $bellow = $(this).next("._bellow");
 			var $siblings = $(this).siblings(".accordion-button.open");
 			var isCollapsing = $(this).closest(".accordion").hasClass("collapsing");
@@ -57,7 +62,20 @@
                 }
                 
 				$(this).addClass("open").attr("aria-pressed", "true");
+				$(this).attr("data-accordion-opened", "true");
 				$bellow.trigger("open");
+
+				if (window.SugarAnalytics) {
+					var openedCount = $accordion.find('.accordion-button[data-accordion-opened="true"]').length;
+					if (openedCount === totalPanels && !$accordion.attr("data-accordion-completed")) {
+						$accordion.attr("data-accordion-completed", "true");
+						window.SugarAnalytics.trackFeature("Accordion", "accordionCompleted", {
+							total_panels: totalPanels
+						}, {
+							dedupeKey: "accordion_completed_" + accordionId
+						});
+					}
+				}
 			}
 		}
 	});
@@ -66,7 +84,20 @@
 	$(".accordion-toggle").on("click keydown", function(e) {
 		if(isActivationEvent(e)) {
 			e.preventDefault();
+			var $accordion = $(this).closest(".accordion");
+			var accordionId = $accordion.attr("data-accordion-instance") || "0";
 			var $closed = $(this).siblings(".accordion-button:not(.open)");
+			var action = $closed.length ? "expand_all" : "collapse_all";
+
+			if (window.SugarAnalytics) {
+				window.SugarAnalytics.trackFeature("Accordion", "accordionToggleAll", {
+					action: action
+				}, {
+					dedupe: false,
+					dedupeKey: "accordion_toggle_" + accordionId + "_" + Date.now()
+				});
+			}
+
 			if($closed.length) {
 				$closed.trigger("click",true);
 			} else {

--- a/source/js/features/checklist.js
+++ b/source/js/features/checklist.js
@@ -8,6 +8,7 @@
 
     function initChecklist() {
         var $checklist = $(this);
+        var checklistAnalyticsId = checklistNumber;
         var $form = $("<form>");
         var $label = $("<label>");
         var $input = '<input type="checkbox">';
@@ -178,6 +179,29 @@
                 }
             } else {
                 alert("Sorry, your browser does not support Web Storage.");
+            }
+
+            trackChecklistCompletion();
+        }
+
+        function trackChecklistCompletion() {
+            if (!window.SugarAnalytics || $checklist.attr("data-checklist-completed")) {
+                return;
+            }
+
+            var $items = $checklist.find("input[type=checkbox]");
+            if (!$items.length) {
+                return;
+            }
+
+            var checkedCount = $items.filter(":checked").length;
+            if (checkedCount === $items.length) {
+                $checklist.attr("data-checklist-completed", "true");
+                window.SugarAnalytics.trackFeature("Checklist", "checklistCompleted", {
+                    total_items: $items.length
+                }, {
+                    dedupeKey: "checklist_completed_" + checklistAnalyticsId
+                });
             }
         }
 

--- a/source/js/features/flashcards.js
+++ b/source/js/features/flashcards.js
@@ -23,8 +23,11 @@
  * Last updated: 2025-09-18
  */
 (() => {
+    let flashcardInstanceIndex = 0;
     // Transform tables with class "flashcards" into interactive flashcard sets
     $("table.flashcards").each(function () {
+        const flashcardInstanceId = flashcardInstanceIndex++;
+
         /**
          * Build a card DOM element from a table row's cells.
          * @param {jQuery} $cells - jQuery collection of <td> elements (front/back)
@@ -216,7 +219,8 @@
 
             // Track current card index
             let currentCardIndex = 0;
-
+            let seenCardIndexes = { 0: true };
+            let hasTrackedDeckCompleted = false;
 
             /**
              * Update the card counter display and currentCardIndex.
@@ -239,6 +243,16 @@
                 
                 currentCardIndex = topIndex;
                 $counter.text(`${currentCardIndex + 1} of ${total}`);
+
+                seenCardIndexes[currentCardIndex] = true;
+                if (!hasTrackedDeckCompleted && total > 0 && Object.keys(seenCardIndexes).length === total && window.SugarAnalytics) {
+                    hasTrackedDeckCompleted = true;
+                    window.SugarAnalytics.trackFeature("Flashcard", "flashcardCompleted", {
+                        total_cards: total
+                    }, {
+                        dedupeKey: "flashcard_completed_" + flashcardInstanceId
+                    });
+                }
             };
 
             // Helper to update ARIA attributes for card faces
@@ -264,8 +278,11 @@
              */
             const initializeCards = () => {
                 currentCardIndex = 0;
+                seenCardIndexes = { 0: true };
+                hasTrackedDeckCompleted = false;
                 updateCounter();
                 $cards = $cardStack.children();
+                
                 $cards.removeClass('flipped top-card bottom-card');
                 $cards.find('.front').attr('aria-hidden', 'false');
                 $cards.find('.back').attr('aria-hidden', 'true');
@@ -289,7 +306,6 @@
                 });
             };
 
-
             $buttons.reset.on("click", () => {
                 $cardStack.empty();
                 $originalCards.each((_, el) => {
@@ -297,8 +313,16 @@
                 });
                 initializeCards();
                 setCardStackHeight();
-            });
 
+                if (window.SugarAnalytics) {
+                    window.SugarAnalytics.trackFeature("Flashcard", "flashcardReset", {
+                        value: 1
+                    }, {
+                        dedupe: false,
+                        dedupeKey: "flashcard_reset_" + flashcardInstanceId + "_" + Date.now()
+                    });
+                }
+            });
 
             $buttons.flipall.on("click", () => {
                 // No change to currentCardIndex
@@ -313,113 +337,20 @@
                         setCardAria($card, true);
                     }
                 });
+
+                if (window.SugarAnalytics) {
+                    window.SugarAnalytics.trackFeature("Flashcard", "flashcardFlipAll", {
+                        value: 1
+                    }, {
+                        dedupe: false,
+                        dedupeKey: "flashcard_flip_all_" + flashcardInstanceId + "_" + Date.now()
+                    });
+                }
             });
 
-            // Create Controls
-
-            $container.append($controls);
-            
-            // Add the original table at the end, after navigation controls
-            $container.append($table);
-
-            // Init Cards
-            initializeCards();
-
-            // --- Swipe gesture support for mobile/tablet when .no-nav is present ---
-            if ($container.hasClass('no-nav')) {
-                let touchStartX = 0, touchStartY = 0, touchEndX = 0, touchEndY = 0;
-                const minSwipeDist = 40; // px
-                $cardStack.on('touchstart', function(e) {
-                    if (e.originalEvent.touches && e.originalEvent.touches.length === 1) {
-                        touchStartX = e.originalEvent.touches[0].clientX;
-                        touchStartY = e.originalEvent.touches[0].clientY;
-                    }
-                });
-                $cardStack.on('touchend', function(e) {
-                    if (e.originalEvent.changedTouches && e.originalEvent.changedTouches.length === 1) {
-                        touchEndX = e.originalEvent.changedTouches[0].clientX;
-                        touchEndY = e.originalEvent.changedTouches[0].clientY;
-                        const dx = touchEndX - touchStartX;
-                        const dy = touchEndY - touchStartY;
-                            if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > minSwipeDist) {
-                                e.preventDefault();
-                                if (dx < 0) {
-                                    $cardStack.trigger('prev'); // swipe left triggers prev
-                                } else {
-                                    $cardStack.trigger('next'); // swipe right triggers next
-                                }
-                        } else if (Math.abs(dy) > minSwipeDist) {
-                            // Vertical swipe
-                            $cardStack.trigger('flip');
-                        }
-                    }
-                });
-            }
-
-
-            // Modularized height/image logic
-
-            /**
-             * Set the height of the card stack using fixed height.
-             * Uses data-height attribute or defaults to 500px.
-             */
-            const setCardStackHeight = () => {
-                const $cards = $cardStack.children('.card');
-                
-                // Check if a fixed height is specified, default to 500px if not
-                const fixedHeight = $table.data('height') || 500;
-                
-                // Set fixed height for cards and card sides
-                $cards.css({
-                    'min-height': `${fixedHeight}px`,
-                    'height': `${fixedHeight}px`
-                });
-                $cards.find('.front, .back').css({
-                    'min-height': `${fixedHeight}px`,
-                    'height': `${fixedHeight}px`
-                });
-                
-                // Constrain images to fit within the card height, leaving room for color stripes
-                const imageHeight = fixedHeight - 15;
-                $cards.find('img').each(function() {
-                    const $img = $(this);
-                    const $card = $img.closest('.card');
-                    
-                    // Don't override styles if the card has alignment classes
-                    const hasAlignmentClass = $card.hasClass('top-left') || 
-                                            $card.hasClass('top-center') || 
-                                            $card.hasClass('top-right') ||
-                                            $card.hasClass('middle-left') || 
-                                            $card.hasClass('middle-center') || 
-                                            $card.hasClass('middle-right') ||
-                                            $card.hasClass('bottom-left') || 
-                                            $card.hasClass('bottom-center') || 
-                                            $card.hasClass('bottom-right');
-                });
-                
-                // Set cardStack height for navigation positioning
-                $cardStack.css('height', `${fixedHeight}px`);
-            };
-
-            setCardStackHeight();
-
-            /*****
-            Events
-            ******/
-
-            // Grouped event handlers for clarity
-            $buttons.viewtable.on("click", function () {
-                const $table = $container.data("flashcard-table");
-                if ($table && $table.length) {
-                    $table.stop().fadeToggle();
-                    $(this).toggleClass("toggled");
-                }
-            }); // 'this' is needed here for the button
-            $buttons.next.on("click", () => $cardStack.trigger("next"));
             $buttons.prev.on("click", () => $cardStack.trigger("prev"));
             $buttons.flip.on("click", () => $cardStack.trigger("flip"));
             $buttons.shuffle.on("click", () => $cardStack.trigger("shuffle"));
-
 
             $cardStack.on("shuffle", function () {
                 $controls.find("button").prop("disabled", true);
@@ -438,8 +369,16 @@
                 $cardStack.empty();
                 $($cardsArr).each((_, el) => { $cardStack.append(el); });
                 initializeCards();
-            });
 
+                if (window.SugarAnalytics) {
+                    window.SugarAnalytics.trackFeature("Flashcard", "flashcardShuffled", {
+                        value: 1
+                    }, {
+                        dedupe: false,
+                        dedupeKey: "flashcard_shuffle_" + flashcardInstanceId + "_" + Date.now()
+                    });
+                }
+            });
 
             // Calculate animation durations once
             swapNextDuration = getAnimationDuration("flashcard-swap-next");
@@ -559,6 +498,15 @@
                         const allowD2LResize = $(this).data('allowD2LResize');
                         if (allowD2LResize) allowD2LResize();
                     }, 500); // CSS transition duration
+
+                    if (window.SugarAnalytics) {
+                        window.SugarAnalytics.trackFeature("Flashcard", "flashcardFlip", {
+                            value: 1
+                        }, {
+                            dedupe: false,
+                            dedupeKey: "flashcard_flip_" + flashcardInstanceId + "_" + Date.now()
+                        });
+                    }
                 }
             });
 

--- a/source/js/features/knowledge-check.js
+++ b/source/js/features/knowledge-check.js
@@ -138,7 +138,7 @@
             if (window.SugarAnalytics) {
                 window.SugarAnalytics.trackFeature("Knowledge Check", "knowledgeCheckSubmitted", {
                     score: score,
-                    total_questions: totalQuestions,
+                    answered_questions: totalQuestions,
                     total_questions_available: questions.length
                 }, {
                     dedupe: false,

--- a/source/js/features/knowledge-check.js
+++ b/source/js/features/knowledge-check.js
@@ -2,6 +2,7 @@
 (function ($) {
     var $knowledgeCheck = $(".knowledge-check, .self-test");
     var identifier = new Identifier();
+
     var markers = {
         correct: "<i class='correct'>✔</i>",
         incorrect: "<i class='incorrect'>❌</i>",
@@ -59,11 +60,11 @@
         });
 
         createKnowledgeCheckForm($questionList, questions, random, isInit);
-
     }
 
     function createKnowledgeCheckForm($replaceable, questions, random, isInit) {
         var $form = $("<form>");
+        var knowledgeCheckId = identifier.getID();
         var $resetButton = $("<button class='reset'>Try Again</button>");
         var $submitButton = buildSubmitButton();
         var questionCount = 0;
@@ -92,13 +93,22 @@
         });
         var $first = $form.children().first();
 
-
         $form.append($submitButton);
         $form.append($resetButton);
         $replaceable.replaceWith($form);
         $form.submit(checkResults);
         $resetButton.on("click", function (e) {
             e.preventDefault();
+
+            if (window.SugarAnalytics) {
+                window.SugarAnalytics.trackFeature("Knowledge Check", "knowledgeCheckReset", {
+                    total_questions: questions.length
+                }, {
+                    dedupe: false,
+                    dedupeKey: "kc_reset_" + knowledgeCheckId + "_" + Date.now()
+                });
+            }
+
             scrollTo($form.parent());
             // Answer is not required on reset
             isInit = false;
@@ -111,16 +121,31 @@
             $form.find("input, select").not("[type='checkbox']").prop("required", true);
         }
 
-
         function checkResults(e) {
             e.preventDefault();
             var $form = $(this);
-
 
             assessInputs();
             reassessment();
             addResetButton();
             scrollTo($form.parent());
+
+            var numCorrect = $form.find(".correct").length;
+            var numIncorrect = $form.find(".incorrect").length;
+            var totalQuestions = numCorrect + numIncorrect;
+            var score = totalQuestions > 0 ? Math.round((numCorrect / totalQuestions) * 100) : 0;
+
+            if (window.SugarAnalytics) {
+                window.SugarAnalytics.trackFeature("Knowledge Check", "knowledgeCheckSubmitted", {
+                    score: score,
+                    total_questions: totalQuestions,
+                    total_questions_available: questions.length
+                }, {
+                    dedupe: false,
+                    dedupeKey: "kc_submit_" + knowledgeCheckId + "_" + Date.now()
+                });
+            }
+
             if (!$(this).closest(".no-score").length) {
                 showScore();
             }
@@ -131,11 +156,10 @@
             }
 
             function showScore() {
-                var numCorrect = $form.find(".correct").length;
-                var numIncorrect = $form.find(".incorrect").length;
                 var $score = $("<div class='score'><p>Score: " + numCorrect + "/" + (numCorrect + numIncorrect) + "</p></div>");
                 $score.hide();
                 $form.prepend($score);
+
                 $score.slideDown();
                 $score.focus();
             }

--- a/source/js/features/line-matching.js
+++ b/source/js/features/line-matching.js
@@ -1,5 +1,7 @@
 (function ($) {
 
+    var lineMatchingInstanceIndex = 0;
+
     // "globals"
     var isClicked = false; // check if the question matching-item is clicked/active
     var answerSequence = []; // Sequence of the clicked matching-item
@@ -101,6 +103,7 @@
     function initLineMatching() {
         var $matching = $(this); // this paticular line matching interaction in the dom
         var matchingObj = new MatchingObject($matching); // read the table and create the "matching object"
+        var lineMatchingId = lineMatchingInstanceIndex++;
 
         // create some arrays to temporarily contain our questions and answers
         let questionsArray = [];
@@ -117,6 +120,10 @@
                 answersArray.push(answerElement);
             });
         });
+
+        $matching.attr("data-line-matching-id", lineMatchingId);
+        $matching.attr("data-line-matching-pairs", answersArray.length);
+        $matching.attr("data-line-matching-completed", "false");
 
         matchingObj.$table.hide(); // hide original table
 
@@ -206,6 +213,7 @@
         $resetButton.insertAfter($matchingContainer);
 
         $resetButton.click(function () {
+
             $matching.find(".matching-item").each(function () {
                 if ($(this).hasClass("overText")) {
                     $(this).attr('class', 'matching-item overText');
@@ -223,7 +231,18 @@
                     $(this).data("remainingAnswers", $(this).data("remainingAnswersDefault"));
                 }
             });
+
+            if (window.SugarAnalytics) {
+                window.SugarAnalytics.trackFeature("Line-Matching", "lineMatchingReset", {
+                    value: 1
+                }, {
+                    dedupe: false,
+                    dedupeKey: "line_matching_reset_" + lineMatchingId + "_" + Date.now()
+                });
+            }
+            $matching.attr("data-line-matching-completed", "false");
         });
+
     }
 
     function selectMatchingItem(event) {
@@ -312,12 +331,12 @@
                     if (newFontSize >= 3) {
                         $(this).css("font-size", newFontSize + "px");
                     }
-    
+
                     childsHeight = 0;
                     $matchingItem.children().not(".connector-line").each(function () {
                         childsHeight += $(this).height();
                     });
-    
+
                     if (childsHeight > 132) {
                         isOverflow = true;
                     } else {
@@ -576,6 +595,21 @@
 
                         } else { // simply use the current clicked item class
                             clickObject.addClass("clicked-item-" + classNum);
+                        }
+
+                        var $matchingRoot = $matchingDiv.closest(".line-matching");
+                        if ($matchingRoot.attr("data-line-matching-completed") !== "true") {
+                            var remainingAnswers = $matchingDiv.children("div").eq(1).find(".matching-item:not([class*='clicked-item-'])").length;
+                            if (remainingAnswers === 0 && window.SugarAnalytics) {
+                                var analyticsId = $matchingRoot.attr("data-line-matching-id") || "0";
+                                var totalPairs = parseInt($matchingRoot.attr("data-line-matching-pairs"), 10) || 0;
+                                $matchingRoot.attr("data-line-matching-completed", "true");
+                                window.SugarAnalytics.trackFeature("Line-Matching", "lineMatchingCompleted", {
+                                    total_pairs: totalPairs
+                                }, {
+                                    dedupeKey: "line_matching_completed_" + analyticsId
+                                });
+                            }
                         }
 
                     }

--- a/source/js/features/printing.js
+++ b/source/js/features/printing.js
@@ -11,6 +11,14 @@ Printing
 	function afterPrinting() {
 		$("_bellow").hide();
 		$(".reveal-button").next().hide();
+		if (window.SugarAnalytics) {
+			window.SugarAnalytics.trackFeature("Printing", "printingCompleted", {
+				value: 1
+			}, {
+				dedupe: false,
+				dedupeKey: "printing_completed_" + Date.now()
+			});
+		}
 	}
 	
 	

--- a/source/js/features/reveal.js
+++ b/source/js/features/reveal.js
@@ -1,10 +1,15 @@
 // SHOW/HIDE CONTENT (#REVEAL)
 
 $(document).ready(function () {
+    var revealInstanceIndex = 0;
     $(".reveal, .active-reveal").each(function () {
+        var revealId = revealInstanceIndex++;
         // Reveal button text
         var buttonText = $(this).data("button") || "Reveal";
         var $button = $("<button class='reveal-button'>" + buttonText + "</button>");
+        var revealType = $(this).hasClass("active-reveal") ? "active" : "regular";
+        $button.attr("data-reveal-id", revealId);
+        $button.attr("data-reveal-type", revealType);
 
         // Minimum length needed in order to enable reveal button
         var inputLength = $(this).data("min-text");
@@ -50,6 +55,16 @@ $(document).ready(function () {
 
 
     $(".reveal-button").click(function () {
+        var $target = $(this).next();
+        var isOpening = !$target.is(":visible");
+        if (isOpening && window.SugarAnalytics) {
+            window.SugarAnalytics.trackFeature("Reveal", "revealActivated", {
+                type: $(this).attr("data-reveal-type") || "regular"
+            }, {
+                dedupeKey: "reveal_activated_" + ($(this).attr("data-reveal-id") || "0")
+            });
+        }
+
         $(this).next().slideToggle("fast").promise().done(function () {
             if ($(this).find(".line-matching")) {
                 $(window).trigger('resize');

--- a/source/js/features/slider.js
+++ b/source/js/features/slider.js
@@ -1,10 +1,14 @@
 (function ($) {
+    var sliderInstanceIndex = 0;
     $(".slider").each(initSlider);
 
     function initSlider() {
         var $slider = $(this);
         var $figureImage = $slider.find(">figure.img");
         var index = new Index($figureImage.length);
+        var sliderInstanceId = sliderInstanceIndex++;
+        var seenSlides = {};
+        var hasTrackedCompletion = false;
 
         $slider.css({"height": "600px", "max-height": "550px", "background-color": "black", "overflow": "hidden"});
 
@@ -47,6 +51,8 @@
             }
         );
         
+        markViewedAndTrack(index.getIndex());
+        
         $figureImage.children("h2").css({"position": "absolute", "background-color": "rgba(51,51,51,.7)", "color": "white"});
         $figureImage.children("img").css({"position": "absolute"});
         $figureImage.children("figcaption").css({"position": "absolute", "background-color": "rgba(51,51,51,.7)", "color": "white"});
@@ -60,12 +66,13 @@
         // Add function to buttons
         $prevButton.on("click", changeImage);
         $nextButton.on("click", changeImage);
-        $fsPrevButton.on("click", changeFullScreenImage);
-        $fsNextButton.on("click", changeFullScreenImage);
+        $fsPrevButton.on("click", {sliderInstanceId: sliderInstanceId}, changeFullScreenImage);
+        $fsNextButton.on("click", {sliderInstanceId: sliderInstanceId}, changeFullScreenImage);
         $modalImages.hide(); // Hide modal/fullscreen mode
         
         // Close fullscreen mode
-        $(".close-fs").click(function () {
+        $slider.find(".close-fs").on("click", {sliderInstanceId: sliderInstanceId}, function (event) {
+
             $("body").css("overflow", "unset");
             $(".full-screen").remove();
             $sliderModal.hide();
@@ -77,7 +84,8 @@
         });
         
         // Show and hide slider caption
-        $(".show-caption").click(function () {
+        $nav.children(".show-caption").on("click", {sliderInstanceId: sliderInstanceId}, function (event) {
+
             $figureImage.children("figcaption").toggle();
             var $toggleButton = $(this).children("button");
             var isOpened = $toggleButton.text().trim() === "Hide caption ▼";
@@ -91,7 +99,8 @@
         });
 
         // Show slider in fullscreen mode
-        $(".show-fullscreen").click(function () {
+        $nav.children(".show-fullscreen").on("click", {sliderInstanceId: sliderInstanceId}, function (event) {
+
             toggleFullScreen();
             var $overlay = $("<div>").addClass("full-screen");
             $slider.append($overlay);
@@ -99,6 +108,14 @@
             $modalImages.eq(index.getIndex()).show().css("opacity", "1");
             $sliderModal.children("button").show();
             $("body").css("overflow", "hidden");
+
+            if (window.SugarAnalytics) {
+                window.SugarAnalytics.trackFeature("Slider", "sliderFullscreen", {
+                    value: 1
+                }, {
+                    dedupeKey: window.SugarAnalytics.makeInstanceKey("slider_fullscreen", sliderInstanceId)
+                });
+            }
         });
 
         // Change the current image to the prev/next image + animation
@@ -139,6 +156,7 @@
                 $nav.children(".show-caption").css({visibility: "visible"});
             }
             
+            markViewedAndTrack(index.getIndex());
         }
 
         // Change image on fullscreen mode
@@ -188,7 +206,28 @@
                 
 
             });
+
+            markViewedAndTrack(index.getIndex());
             
+        }
+
+        function markViewedAndTrack(currentIndex) {
+            seenSlides[currentIndex] = true;
+
+            if (hasTrackedCompletion) {
+                return;
+            }
+
+            if (Object.keys(seenSlides).length === $figureImage.length && $figureImage.length > 0) {
+                hasTrackedCompletion = true;
+                if (window.SugarAnalytics) {
+                    window.SugarAnalytics.trackFeature("Slider", "sliderCompleted", {
+                        total_images: $figureImage.length
+                    }, {
+                        dedupeKey: window.SugarAnalytics.makeInstanceKey("slider_completed", sliderInstanceId)
+                    });
+                }
+            }
         }
 
         function Index(_length) {

--- a/source/js/features/swapper.js
+++ b/source/js/features/swapper.js
@@ -1,8 +1,11 @@
 (function ($) {
+	var swapperInstanceIndex = 0;
 	$(".swapper").each(initSwapper);
 
 	function initSwapper() {
 		var $swapper = $(this); // used in handleButtonPress
+		var swapperId = swapperInstanceIndex++;
+		var hasTrackedActivation = false;
 		var $slides = $(this).children(); // used in handleButtonPress
 		var index = new Index($slides.length); // used in handleButtonPress
 		var $youtube = $swapper.find("iframe[src*='youtube']"); // used in handleButtonPress
@@ -25,6 +28,15 @@
 		enableYoutubeJSAPI($youtube);
 
 		function handleButtonPress() {
+			if (!hasTrackedActivation && window.SugarAnalytics) {
+				hasTrackedActivation = true;
+				window.SugarAnalytics.trackFeature("Swapper", "swapperActivated", {
+					value: 1
+				}, {
+					dedupeKey: "swapper_activated_" + swapperId
+				});
+			}
+
 			var isNext = $(this).is(".next");
 			var $showing = $slides.filter(":visible");
 			var buttonBoxHeight = $buttonBox.outerHeight(true);

--- a/source/js/features/tabs.js
+++ b/source/js/features/tabs.js
@@ -1,6 +1,10 @@
 (function () {
+    var tabsInstanceIndex = 0;
     $(".tabs").each(function (index) {
         let $tab = $(this);
+        var tabsInstanceId = tabsInstanceIndex++;
+        var viewedTabs = { 0: true };
+        var hasTrackedCompletion = false;
         var tabHeading = $tab.children().first().prop("tagName");
         var tabTexts = [];
         var $tabNav = $("<ul class='tab-nav'>");
@@ -69,6 +73,18 @@
             var selectedTabColor = $tabNav.children("li").eq(selectedTabIndex).css("border-bottom-color");
             $tabNav.css("border-bottom-color", selectedTabColor);
             $tabBody.css("border-color", selectedTabColor);
+
+            viewedTabs[idx] = true;
+            if (!hasTrackedCompletion && Object.keys(viewedTabs).length === $tabContents.length && $tabContents.length > 0) {
+                hasTrackedCompletion = true;
+                if (window.SugarAnalytics) {
+                    window.SugarAnalytics.trackFeature("Tabs", "tabsCompleted", {
+                        total_tabs: $tabContents.length
+                    }, {
+                        dedupeKey: window.SugarAnalytics.makeInstanceKey("tabs_completed", tabsInstanceId)
+                    });
+                }
+            }
         });
         $tabBody.css("border-color", $tabNav.children("li.selected").css("border-color"));
     });


### PR DESCRIPTION
Closes issue #11 

### Summary
Added custom properties to Plausible analytics tracking calls across all interactive features to enable better event tracking and data analysis. Updated the analytics tracker core to properly pass contextual data through the props parameter to Plausible.

### Changes
Updated analytics tracking implementation in the following features to include custom properties:

- **Analytics Tracker** - Updated core trackEvent, trackFeature, and trackPageStats methods to properly format and pass custom properties to Plausible
- **Page Stats** - Added properties for feature counts, learning block types, custom interactions, media file types, and legacy class detection
- **Accordion** - Added properties for accordion completion tracking (total panels) and toggle all actions
- **Checklist** - Added properties for checklist completion tracking (total items)
- **Flashcards** - Added properties for flip, flip all, shuffle, reset, and deck completion events with total card counts
- **Knowledge Check** - Added properties for submission tracking (score, total questions) and reset events
- **Line Matching** - Added properties for completion tracking (total pairs) and reset events
- **Printing** - Added properties for print completion events
- **Reveal** - Added properties for reveal activation tracking (type: active/regular)
- **Slider** - Added properties for fullscreen activation and slider completion tracking (total images)
- **Swapper** - Added properties for swapper activation tracking
- **Tabs** - Added properties for tabs completion tracking (total tabs)
